### PR TITLE
#33 pow_modを原典準拠にする

### DIFF
--- a/Math/MathLib.java
+++ b/Math/MathLib.java
@@ -22,13 +22,16 @@ class MathLib{
         return new long[]{s,m0};
     }
 
-    public static long pow_mod(long x, long n, long m){
-        assert(n >= 0 && m >= 1);
-        long ans = 1;
+    public static long pow_mod(long x, long n, int m){
+        assert n >= 0;
+        assert m >= 1;
+        if(m == 1)return 0L;
+        x = safe_mod(x, m);
+        long ans = 1L;
         while(n > 0){
-            if(n%2==1) ans = (ans * x) % m;
+            if((n&1) == 1) ans = (ans * x) % m;
             x = (x*x) % m;
-            n /= 2;
+            n >>>= 1;
         }
         return ans;
     }


### PR DESCRIPTION
#33 

原典とコードをほぼ同じに

- `m`の制約を`int`に
- `&&`でつなぐassertionは複数行のほうが引っかかったときの原因がすぐにわかるのでそうする
- `m=1`を場合分け(`x=1%m`としてもよい)
- `x`の初期値を`safe_mod`で求める
- `%2`, `/2`を`&1`, `>>>=1`として2%高速化(ローカル測定)
- [AOJ/NTL_1_B](https://onlinejudge.u-aizu.ac.jp/courses/library/6/NTL/1/NTL_1_B), [SPOJ/MODPOW](https://www.spoj.com/problems/MODPOW/), [SPOJ/FASTPOW](https://www.spoj.com/problems/FASTPOW/) でverified. ただしどれも`pow_mod`の引数の範囲を網羅できているわけではない。
