### PR TITLE
#46 MaxFlow が停止しないバグの修正

### DIFF
--- a/MaxFlow/MaxFlow.java
+++ b/MaxFlow/MaxFlow.java
@@ -98,6 +98,7 @@ class MaxFlow {
                 long d = dinicDFS(t, s, flowLimit - flow, iter, level);
                 if (d <= 0) break;
                 flow += d;
+                if (flow == flowLimit) return flow;
             }
         }
     }


### PR DESCRIPTION
#46 flow メソッドにおいて流量上限に最大流量よりも小さい値を指定した場合に停止しないバグを修正