### PR TITLE
Fix printArray bug

### DIFF
--- a/ContestIO/ContestPrinter.java
+++ b/ContestIO/ContestPrinter.java
@@ -60,10 +60,10 @@ class ContestPrinter extends java.io.PrintWriter{
             super.print(map.applyAsInt(array[i]));
             super.print(separator);
         }
-        super.println(array[n-1]);
+        super.println(map.applyAsInt(array[n-1]));
     }
     public void printArray(int[] array, java.util.function.IntUnaryOperator map){
-        this.printArray(array, map);
+        this.printArray(array, " ", map);
     }
 
     public void printArray(long[] array, String separator){
@@ -83,10 +83,10 @@ class ContestPrinter extends java.io.PrintWriter{
             super.print(map.applyAsLong(array[i]));
             super.print(separator);
         }
-        super.println(array[n-1]);
+        super.println(map.applyAsLong(array[n-1]));
     }
-    public void printArray(long[] array, java.util.function.IntUnaryOperator map){
-        this.printArray(array, map);
+    public void printArray(long[] array, java.util.function.LongUnaryOperator map){
+        this.printArray(array, " ", map);
     }
     
 }


### PR DESCRIPTION
・66 行目と 89 行目で引数が (array, map) となっておりオーバーロードしていたため、 (array, " ", map) に変更し同名の別の関数を呼び出すことで修正しました。
・63 行目と 86 行目で配列の最後の要素のみ map が作用していなかったため、 map.applyAsLong(array[n-1]) に変更することにより修正しました。
・88 行目で long 型の配列に int 型の map が作用していたため、 long 型の map に変更することにより修正しました。